### PR TITLE
Fix multiple users with the same name being online

### DIFF
--- a/hnet/handler.go
+++ b/hnet/handler.go
@@ -55,6 +55,13 @@ func handleLogin(stream *common.IOStream, player *Player) error {
 		return nil
 	}
 
+	otherUser := player.Server.Players.ByID(uint32(userObject.Id))
+
+	if otherUser != nil {
+		otherUser.RevokeLogin()
+		otherUser.CloseConnection()
+	}
+
 	// Ensure that the stats object exists
 	userObject.EnsureStats(player.Server.State)
 

--- a/hnet/handler.go
+++ b/hnet/handler.go
@@ -58,7 +58,6 @@ func handleLogin(stream *common.IOStream, player *Player) error {
 	otherUser := player.Server.Players.ByID(uint32(userObject.Id))
 
 	if otherUser != nil {
-		otherUser.RevokeLogin()
 		otherUser.CloseConnection()
 	}
 

--- a/hnet/handler.go
+++ b/hnet/handler.go
@@ -27,7 +27,7 @@ func handleLogin(stream *common.IOStream, player *Player) error {
 	)
 
 	if err != nil {
-		player.RevokeLogin()
+		player.CloseConnection()
 		player.Logger.Warning("Login attempt failed: User not found")
 		return nil
 	}
@@ -38,19 +38,19 @@ func handleLogin(stream *common.IOStream, player *Player) error {
 	)
 
 	if err != nil {
-		player.RevokeLogin()
+		player.CloseConnection()
 		player.Logger.Warning("Login attempt failed: Incorrect password")
 		return nil
 	}
 
 	if !userObject.Activated {
-		player.RevokeLogin()
+		player.CloseConnection()
 		player.Logger.Warning("Login attempt failed: Account not activated")
 		return nil
 	}
 
 	if userObject.Restricted {
-		player.RevokeLogin()
+		player.CloseConnection()
 		player.Logger.Warning("Login attempt failed: Account restricted")
 		return nil
 	}
@@ -93,7 +93,7 @@ func handleLogin(stream *common.IOStream, player *Player) error {
 	// Send login response
 	err = player.SendPacket(SERVER_LOGIN_RESPONSE, response)
 	if err != nil {
-		player.RevokeLogin()
+		player.CloseConnection()
 		return err
 	}
 

--- a/hnet/player.go
+++ b/hnet/player.go
@@ -48,6 +48,7 @@ func (player *Player) OnDisconnect() {
 }
 
 func (player *Player) CloseConnection() {
+	player.RevokeLogin()
 	player.OnDisconnect()
 }
 

--- a/hnet/player.go
+++ b/hnet/player.go
@@ -47,6 +47,10 @@ func (player *Player) OnDisconnect() {
 	player.Conn.Close()
 }
 
+func (player *Player) CloseConnection() {
+	player.OnDisconnect()
+}
+
 func (player *Player) LogIncomingPacket(packetId uint32, packet Serializable) {
 	player.Logger.Debugf("-> %d: %s", packetId, packet.String())
 }


### PR DESCRIPTION
This pr logs out any other user with the same name that is currently online on login, which prevents multiple users with the same name being online.