### PR TITLE
Implement quit packet

### DIFF
--- a/hnet/constants.go
+++ b/hnet/constants.go
@@ -14,6 +14,7 @@ const (
 	SERVER_LOGIN_REVOKED        uint32 = 3
 	SERVER_USER_STATS           uint32 = 5
 	SERVER_USER_INFO            uint32 = 6
+	SERVER_USER_QUIT            uint32 = 7
 	SERVER_FRIENDS_LIST         uint32 = 8
 	SERVER_LEADERBOARD_RESPONSE uint32 = 25
 )

--- a/hnet/objects.go
+++ b/hnet/objects.go
@@ -222,3 +222,14 @@ func NewFriendsList() *FriendsList {
 		FriendIds: []uint32{},
 	}
 }
+
+type QuitResponse struct {
+	UserId uint32
+}
+
+func (response QuitResponse) String() string {
+	return fmt.Sprintf(
+		"QuitResponse{UserId: %d}",
+		response.UserId,
+	)
+}

--- a/hnet/player.go
+++ b/hnet/player.go
@@ -44,6 +44,7 @@ func (player *Player) OnConnect() {
 func (player *Player) OnDisconnect() {
 	player.Logger.Infof("Disconnected -> <%s>", player.Conn.RemoteAddr())
 	player.Server.Players.Remove(player)
+	player.Server.Players.Broadcast(SERVER_USER_QUIT, &QuitResponse{player.Info.Id})
 	player.Conn.Close()
 }
 

--- a/hnet/writers.go
+++ b/hnet/writers.go
@@ -77,3 +77,8 @@ func (request StatsRequest) Serialize(stream *common.IOStream) {
 func (friends FriendsList) Serialize(stream *common.IOStream) {
 	stream.WriteIntList(friends.FriendIds)
 }
+
+func (response QuitResponse) Serialize(stream *common.IOStream) {
+	stream.WriteU8(0) // TODO: Unused?
+	stream.WriteU32(response.UserId)
+}


### PR DESCRIPTION
This pr implements the quit packet, which also means we have found the structure for a lot of other packets:
```c
someBoolList[0] = 0; // This is actually a u8/boolean, unused in most cases
someInteger = 0;     // This is the u32 userId we are looking for
DataStream::operator>>(dataStream, someBoolList);
QDataStream::operator>>(dataStream, &someInteger);
```