### PR TITLE
Implement reconnect packet & response password hashing

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/crypto v0.17.0
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gorm.io/gorm v1.25.12

--- a/common/passwords.go
+++ b/common/passwords.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"crypto/sha512"
+	"encoding/hex"
 
 	"golang.org/x/crypto/bcrypt"
 )
@@ -60,6 +61,16 @@ func CheckPasswordHashed(inputHashed []byte, bcryptString string) bool {
 	isCorrect := err == nil
 	passwordCache[string(inputHashed)] = isCorrect
 	return isCorrect
+}
+
+func CheckPasswordHashedHex(inputHex string, bcryptString string) bool {
+	inputHashed, err := hex.DecodeString(inputHex)
+
+	if err != nil {
+		return false
+	}
+
+	return CheckPasswordHashed(inputHashed, bcryptString)
 }
 
 func GetSHA512Hash(input string) []byte {

--- a/common/passwords.go
+++ b/common/passwords.go
@@ -1,0 +1,70 @@
+package common
+
+import (
+	"crypto/sha512"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+var passwordCache = map[string]bool{}
+
+func GetPasswordCache() map[string]bool {
+	return passwordCache
+}
+
+func ClearPasswordCache() {
+	passwordCache = map[string]bool{}
+}
+
+func CreatePasswordHash(password string) (string, error) {
+	hashedPassword := GetSHA512Hash(password)
+	hashedBytes, err := bcrypt.GenerateFromPassword(
+		hashedPassword,
+		bcrypt.DefaultCost,
+	)
+
+	return string(hashedBytes), err
+}
+
+func CheckPassword(input string, bcryptString string) bool {
+	inputHashed := GetSHA512Hash(input)
+
+	if isCorrect, ok := passwordCache[string(inputHashed)]; ok {
+		return isCorrect
+	}
+
+	err := bcrypt.CompareHashAndPassword(
+		[]byte(bcryptString),
+		inputHashed,
+	)
+
+	isCorrect := err == nil
+	passwordCache[string(inputHashed)] = isCorrect
+	return isCorrect
+}
+
+func CheckPasswordHashed(inputHashed []byte, bcryptString string) bool {
+	if len(inputHashed) != sha512.Size {
+		return false
+	}
+
+	if isCorrect, ok := passwordCache[string(inputHashed)]; ok {
+		return isCorrect
+	}
+
+	err := bcrypt.CompareHashAndPassword(
+		[]byte(bcryptString),
+		inputHashed,
+	)
+
+	isCorrect := err == nil
+	passwordCache[string(inputHashed)] = isCorrect
+	return isCorrect
+}
+
+func GetSHA512Hash(input string) []byte {
+	hash := sha512.New()
+	hash.Write([]byte(input))
+	hashedBytes := hash.Sum(nil)
+	return hashedBytes
+}

--- a/common/passwords_test.go
+++ b/common/passwords_test.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestPasswords(t *testing.T) {
+	password := "password"
+	hash, err := CreatePasswordHash(password)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if !CheckPassword(password, hash) {
+		t.Error("password check failed")
+		return
+	}
+
+	passwordHashed := GetSHA512Hash(password)
+
+	if !CheckPasswordHashed(passwordHashed, hash) {
+		t.Error("hashed password check failed")
+		return
+	}
+
+	if len(passwordCache) != 1 {
+		t.Error("password cache should have 1 entry")
+		return
+	}
+}

--- a/hnet/handler.go
+++ b/hnet/handler.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/hexis-revival/hexagon/common"
-	"golang.org/x/crypto/bcrypt"
 )
 
 var Handlers = map[uint32]func(*common.IOStream, *Player) error{}
@@ -35,12 +34,12 @@ func handleLogin(stream *common.IOStream, player *Player) error {
 		return nil
 	}
 
-	err = bcrypt.CompareHashAndPassword(
-		[]byte(userObject.Password),
-		[]byte(request.Password),
+	isCorrect := common.CheckPassword(
+		request.Password,
+		userObject.Password,
 	)
 
-	if err != nil {
+	if !isCorrect {
 		player.OnLoginFailed("Incorrect password")
 		return nil
 	}

--- a/hnet/parsers.go
+++ b/hnet/parsers.go
@@ -15,6 +15,7 @@ func ReadLoginRequest(stream *common.IOStream) *LoginRequest {
 	minorVersion := stream.ReadU32()
 	patchVersion := stream.ReadU32()
 	clientInfo := stream.ReadString()
+	_ = stream.ReadU8() // TODO
 
 	version := &VersionInfo{
 		Major: majorVersion,

--- a/hnet/parsers.go
+++ b/hnet/parsers.go
@@ -33,6 +33,41 @@ func ReadLoginRequest(stream *common.IOStream) *LoginRequest {
 	}
 }
 
+func ReadLoginRequestReconnect(stream *common.IOStream) *LoginRequest {
+	defer handlePanic()
+
+	username := stream.ReadString()
+	password := stream.ReadString()
+
+	// Reconnect packet contains extra 4 bytes of null bytes
+	_ = stream.ReadU32()
+
+	majorVersion := stream.ReadU32()
+	minorVersion := stream.ReadU32()
+	patchVersion := stream.ReadU32()
+	clientInfo := stream.ReadString()
+	_ = stream.ReadU8() // TODO
+
+	// At the end there are an extra 4 bytes
+	// {0xFF, 0xFF, 0xFF, 0xFF}
+	_ = stream.ReadU32()
+
+	version := &VersionInfo{
+		Major: majorVersion,
+		Minor: minorVersion,
+		Patch: patchVersion,
+	}
+
+	client := ParseClientInfo(clientInfo)
+	client.Version = version
+
+	return &LoginRequest{
+		Username: username,
+		Password: password,
+		Client:   client,
+	}
+}
+
 func ParseClientInfo(clientInfoString string) *ClientInfo {
 	parts := strings.Split(clientInfoString, ";")
 	adapters := strings.Split(parts[1], ",")

--- a/hnet/player.go
+++ b/hnet/player.go
@@ -2,6 +2,7 @@ package hnet
 
 import (
 	"encoding/binary"
+	"fmt"
 	"net"
 
 	"github.com/hexis-revival/hexagon/common"
@@ -73,6 +74,70 @@ func (player *Player) SendPacket(packetId uint32, packet Serializable) error {
 	stream := common.NewIOStream([]byte{}, binary.BigEndian)
 	packet.Serialize(stream)
 	return player.SendPacketData(packetId, stream.Get())
+}
+
+func (player *Player) OnLoginSuccess(request *LoginRequest, userObject *common.User) error {
+	otherUser := player.Server.Players.ByID(uint32(userObject.Id))
+
+	if otherUser != nil {
+		// Another user with this account is online
+		otherUser.CloseConnection()
+	}
+
+	// Ensure that the stats object exists
+	userObject.EnsureStats(player.Server.State)
+
+	// Populate player info & stats
+	player.ApplyUserData(userObject)
+	player.Server.Players.Add(player)
+
+	player.Logger.Infof(
+		"Login attempt as '%s' with version %s",
+		player.Info.Name,
+		player.Client.Version.String(),
+	)
+
+	player.Logger.SetName(fmt.Sprintf(
+		"Player \"%s\"",
+		player.Info.Name,
+	))
+
+	for _, other := range player.Server.Players.All() {
+		other.SendPacket(SERVER_USER_INFO, player.Info)
+		player.SendPacket(SERVER_USER_INFO, other.Info)
+	}
+
+	response := LoginResponse{
+		UserId:   player.Info.Id,
+		Username: player.Info.Name,
+		Password: request.Password,
+	}
+
+	// Send login response
+	err := player.SendPacket(SERVER_LOGIN_RESPONSE, response)
+	if err != nil {
+		player.CloseConnection()
+		return err
+	}
+
+	friendIds, err := player.GetFriendIds()
+	if err != nil {
+		return err
+	}
+
+	// Send friends list
+	friendsList := FriendsList{FriendIds: friendIds}
+	err = player.SendPacket(SERVER_FRIENDS_LIST, friendsList)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (player *Player) OnLoginFailed(reason string) {
+	player.Logger.Warningf("Login attempt failed: %s", reason)
+	player.CloseConnection()
 }
 
 func (player *Player) RevokeLogin() error {

--- a/hnet/player.go
+++ b/hnet/player.go
@@ -2,7 +2,6 @@ package hnet
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"net"
 
@@ -77,7 +76,7 @@ func (player *Player) SendPacket(packetId uint32, packet Serializable) error {
 	return player.SendPacketData(packetId, stream.Get())
 }
 
-func (player *Player) OnLoginSuccess(request *LoginRequest, userObject *common.User) error {
+func (player *Player) OnLoginSuccess(responsePassword string, userObject *common.User) error {
 	otherUser := player.Server.Players.ByID(uint32(userObject.Id))
 
 	if otherUser != nil {
@@ -108,13 +107,10 @@ func (player *Player) OnLoginSuccess(request *LoginRequest, userObject *common.U
 		player.SendPacket(SERVER_USER_INFO, other.Info)
 	}
 
-	responsePassword := common.GetSHA512Hash(request.Password)
-	responsePasswordHex := hex.EncodeToString(responsePassword)
-
 	response := LoginResponse{
 		UserId:   player.Info.Id,
 		Username: player.Info.Name,
-		Password: responsePasswordHex,
+		Password: responsePassword,
 	}
 
 	// Send login response

--- a/hnet/player.go
+++ b/hnet/player.go
@@ -2,6 +2,7 @@ package hnet
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"net"
 
@@ -107,10 +108,13 @@ func (player *Player) OnLoginSuccess(request *LoginRequest, userObject *common.U
 		player.SendPacket(SERVER_USER_INFO, other.Info)
 	}
 
+	responsePassword := common.GetSHA512Hash(request.Password)
+	responsePasswordHex := hex.EncodeToString(responsePassword)
+
 	response := LoginResponse{
 		UserId:   player.Info.Id,
 		Username: player.Info.Name,
-		Password: request.Password,
+		Password: responsePasswordHex,
 	}
 
 	// Send login response


### PR DESCRIPTION
Resolves: #14 

As mentioned in the issue, the game has 2 packets for logging in. A normal "Login" packet, which sends over the password in plaintext, as well as a "Reconnect" packet, which sends over whatever the server set as a response password at the first login response. My theory is that this was used for password hashing, so I took the advantage and implemented it.
And guess what? It works!