### PR TITLE
Add beatmap database schema & preloading system

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -20,3 +20,20 @@ const (
 	StatusFriend  RelationshipStatus = "friend"
 	StatusBlocked RelationshipStatus = "blocked"
 )
+
+type BeatmapStatus int
+
+const (
+	StatusUnknown      BeatmapStatus = iota
+	StatusNotSubmitted BeatmapStatus = iota
+	StatusPending      BeatmapStatus = iota
+	StatusRanked       BeatmapStatus = iota
+	StatusApproved     BeatmapStatus = iota
+)
+
+type BeatmapAvailability int
+
+const (
+	BeatmapHasDownload BeatmapAvailability = iota
+	BeatmapHasDMCA     BeatmapAvailability = iota
+)

--- a/common/database_queries.go
+++ b/common/database_queries.go
@@ -114,6 +114,28 @@ func FetchUserRelationship(userId int, targetId int, state *State) (*Relationshi
 	return relationship, nil
 }
 
+func FetchBeatmapsetById(id int, state *State, preload ...string) (*Beatmapset, error) {
+	beatmapset := &Beatmapset{}
+	result := preloadQuery(state, preload).First(beatmapset, id)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return beatmapset, nil
+}
+
+func FetchBeatmapById(id int, state *State, preload ...string) (*Beatmap, error) {
+	beatmap := &Beatmap{}
+	result := preloadQuery(state, preload).First(beatmap, id)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return beatmap, nil
+}
+
 func preloadQuery(state *State, preload []string) *gorm.DB {
 	result := state.Database
 

--- a/common/database_queries.go
+++ b/common/database_queries.go
@@ -92,9 +92,10 @@ func RemoveUserRelationship(relationship *Relationship, state *State) error {
 	return nil
 }
 
-func FetchUserRelationships(userId int, status RelationshipStatus, state *State) ([]*Relationship, error) {
+func FetchUserRelationships(userId int, status RelationshipStatus, state *State, preload ...string) ([]*Relationship, error) {
 	relationships := []*Relationship{}
-	result := state.Database.Where("user_id = ? AND status = ?", userId, status).Find(&relationships)
+	query := preloadQuery(state, preload).Where("user_id = ? AND status = ?", userId, status)
+	result := query.Find(&relationships)
 
 	if result.Error != nil {
 		return nil, result.Error
@@ -103,9 +104,9 @@ func FetchUserRelationships(userId int, status RelationshipStatus, state *State)
 	return relationships, nil
 }
 
-func FetchUserRelationship(userId int, targetId int, state *State) (*Relationship, error) {
+func FetchUserRelationship(userId int, targetId int, state *State, preload ...string) (*Relationship, error) {
 	relationship := &Relationship{}
-	result := state.Database.First(relationship, "user_id = ? AND target_id = ?", userId, targetId)
+	result := preloadQuery(state, preload).First(relationship, "user_id = ? AND target_id = ?", userId, targetId)
 
 	if result.Error != nil {
 		return nil, result.Error

--- a/common/database_queries.go
+++ b/common/database_queries.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"strings"
+
+	"gorm.io/gorm"
 )
 
 func CreateUser(user *User, state *State) error {
@@ -110,4 +112,14 @@ func FetchUserRelationship(userId int, targetId int, state *State) (*Relationshi
 	}
 
 	return relationship, nil
+}
+
+func preloadQuery(state *State, preload []string) *gorm.DB {
+	result := state.Database
+
+	for _, p := range preload {
+		result = result.Preload(p)
+	}
+
+	return result
 }

--- a/common/database_queries.go
+++ b/common/database_queries.go
@@ -16,9 +16,9 @@ func CreateUser(user *User, state *State) error {
 	return nil
 }
 
-func FetchUserById(id int, state *State) (*User, error) {
+func FetchUserById(id int, state *State, preload ...string) (*User, error) {
 	user := &User{}
-	result := state.Database.Preload("Stats").First(user, id)
+	result := preloadQuery(state, preload).First(user, id)
 
 	if result.Error != nil {
 		return nil, result.Error
@@ -27,10 +27,10 @@ func FetchUserById(id int, state *State) (*User, error) {
 	return user, nil
 }
 
-func FetchUserByName(name string, state *State) (*User, error) {
+func FetchUserByName(name string, state *State, preload ...string) (*User, error) {
 	user := &User{}
-	query := state.Database.Where("name = ?", name)
-	result := query.Preload("Stats").First(user)
+	query := preloadQuery(state, preload).Where("name = ?", name)
+	result := query.First(user)
 
 	if result.Error != nil {
 		return nil, result.Error
@@ -39,10 +39,10 @@ func FetchUserByName(name string, state *State) (*User, error) {
 	return user, nil
 }
 
-func FetchUserByNameCaseInsensitive(name string, state *State) (*User, error) {
+func FetchUserByNameCaseInsensitive(name string, state *State, preload ...string) (*User, error) {
 	user := &User{}
-	result := state.Database.Where("lower(name) = ?", strings.ToLower(name))
-	result = result.Preload("Stats").First(user)
+	query := preloadQuery(state, preload).Where("lower(name) = ?", strings.ToLower(name))
+	result := query.First(user)
 
 	if result.Error != nil {
 		return nil, result.Error

--- a/common/database_schemas.go
+++ b/common/database_schemas.go
@@ -1,6 +1,10 @@
 package common
 
-import "time"
+import (
+	"time"
+
+	"github.com/lib/pq"
+)
 
 type User struct {
 	Id             int       `gorm:"primaryKey;autoIncrement;not null"`
@@ -53,4 +57,55 @@ func (user *User) EnsureStats(state *State) error {
 	// Create new stats object
 	user.Stats = Stats{UserId: user.Id}
 	return CreateStats(&user.Stats, state)
+}
+
+type Beatmapset struct {
+	Id                 int                 `gorm:"primaryKey;autoIncrement;not null"`
+	Title              string              `gorm:"size:255;not null"`
+	Artist             string              `gorm:"size:255;not null"`
+	Source             string              `gorm:"size:255;not null"`
+	Tags               pq.StringArray      `gorm:"type:text[];not null;default:'{}'"`
+	CreatorId          int                 `gorm:"not null"`
+	CreatedAt          time.Time           `gorm:"not null;default:now()"`
+	LastUpdated        time.Time           `gorm:"not null;default:now()"`
+	ApprovedAt         time.Time           `gorm:"default:null"`
+	ApprovedBy         int                 `gorm:"default:null"`
+	Status             BeatmapStatus       `gorm:"not null"`
+	Description        string              `gorm:"type:text;not null"`
+	HasVideo           bool                `gorm:"not null;default:false"`
+	AvailabilityStatus BeatmapAvailability `gorm:"not null"`
+	AvailabilityInfo   string              `gorm:"type:text;not null"`
+
+	Beatmaps []Beatmap `gorm:"foreignKey:SetId"`
+	Creator  User      `gorm:"foreignKey:CreatorId"`
+}
+
+type Beatmap struct {
+	Id            int           `gorm:"primaryKey;autoIncrement;not null"`
+	SetId         int           `gorm:"not null"`
+	Checksum      string        `gorm:"size:32;not null"`
+	Version       string        `gorm:"size:255;not null"`
+	Filename      string        `gorm:"size:512;not null"`
+	CreatorId     int           `gorm:"not null"`
+	CreatedAt     time.Time     `gorm:"not null;default:now()"`
+	LastUpdated   time.Time     `gorm:"not null;default:now()"`
+	Status        BeatmapStatus `gorm:"not null"`
+	TotalLength   int           `gorm:"not null;default:0"`
+	DrainLength   int           `gorm:"not null;default:0"`
+	TotalCircles  int           `gorm:"not null;default:0"`
+	TotalSliders  int           `gorm:"not null;default:0"`
+	TotalSpinners int           `gorm:"not null;default:0"`
+	TotalHolds    int           `gorm:"not null;default:0"`
+	MaxCombo      int           `gorm:"not null;default:0"`
+	MedianBpm     float64       `gorm:"not null;default:0"`
+	HighestBpm    float64       `gorm:"not null;default:0"`
+	LowestBpm     float64       `gorm:"not null;default:0"`
+	CS            float64       `gorm:"not null;default:0"`
+	HP            float64       `gorm:"not null;default:0"`
+	OD            float64       `gorm:"not null;default:0"`
+	AR            float64       `gorm:"not null;default:0"`
+	SR            float64       `gorm:"not null;default:0"`
+
+	Set     Beatmapset `gorm:"foreignKey:SetId"`
+	Creator User       `gorm:"foreignKey:CreatorId"`
 }

--- a/common/go.mod
+++ b/common/go.mod
@@ -23,6 +23,7 @@ require (
 )
 
 require (
+	github.com/lib/pq v1.10.9
 	github.com/pkg/errors v0.9.1
 	github.com/redis/go-redis/v9 v9.6.1
 	gorm.io/driver/postgres v1.5.9

--- a/common/go.sum
+++ b/common/go.sum
@@ -21,6 +21,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/redis/go-redis/v9 v9.6.1 // indirect
 	golang.org/x/crypto v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/hnet/go.mod
+++ b/hnet/go.mod
@@ -4,6 +4,8 @@ go 1.22.7
 
 require github.com/hexis-revival/hexagon/common v0.0.0-00010101000000-000000000000
 
+require github.com/lib/pq v1.10.9 // indirect
+
 require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/hnet/go.sum
+++ b/hnet/go.sum
@@ -23,6 +23,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/hnet/handler.go
+++ b/hnet/handler.go
@@ -28,6 +28,7 @@ func handleLogin(stream *common.IOStream, player *Player) error {
 	userObject, err := common.FetchUserByNameCaseInsensitive(
 		request.Username,
 		player.Server.State,
+		"Stats",
 	)
 
 	if err != nil {
@@ -80,6 +81,7 @@ func handleReconnect(stream *common.IOStream, player *Player) error {
 	userObject, err := common.FetchUserByNameCaseInsensitive(
 		request.Username,
 		player.Server.State,
+		"Stats",
 	)
 
 	if err != nil {

--- a/hscore/go.mod
+++ b/hscore/go.mod
@@ -6,6 +6,8 @@ replace github.com/hexis-revival/hexagon/common => ../common
 
 require github.com/hexis-revival/hexagon/common v0.0.0-20241005191625-f1f1499b1fd1
 
+require github.com/lib/pq v1.10.9 // indirect
+
 require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/hscore/go.sum
+++ b/hscore/go.sum
@@ -23,6 +23,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
This pr adds the new beatmap & beatmapset table schemas from [this pr](https://github.com/hexis-revival/hexagon-deploy/pull/1) over to hexagon.
I've also added a way to dynamically preload gorm relationships to make our lives a bit easier. For example, to load a beatmap with it's `Set` relationship, you can now use `common.FetchBeatmapById(<id>, state, "Set")`.