### PR TITLE
Add beatmap header to leaderboard response

### DIFF
--- a/hnet/handler.go
+++ b/hnet/handler.go
@@ -267,6 +267,11 @@ func handleUserRelationshipRemove(stream *common.IOStream, player *Player) error
 
 func handleLeaderboardRequest(stream *common.IOStream, player *Player) error {
 	request := ReadLeaderboardRequest(stream)
+
+	if request == nil {
+		return fmt.Errorf("failed to read leaderboard request")
+	}
+
 	player.LogIncomingPacket(CLIENT_LEADERBOARD_REQUEST, request)
 
 	response := &LeaderboardResponse{
@@ -281,8 +286,9 @@ func handleLeaderboardRequest(stream *common.IOStream, player *Player) error {
 	if err != nil {
 		if err.Error() == "record not found" {
 			player.SendPacket(SERVER_LEADERBOARD_RESPONSE, response)
-			return err
 		}
+
+		return err
 	}
 
 	response.NeedsUpdate = request.BeatmapChecksum != beatmap.Checksum

--- a/hnet/objects.go
+++ b/hnet/objects.go
@@ -269,3 +269,27 @@ type Mods struct {
 func (mods *Mods) String() string {
 	return common.FormatStruct(mods)
 }
+
+type LeaderboardRequest struct {
+	BeatmapChecksum string
+	Unknown         uint64
+	SetId           uint32
+	BeatmapId       uint32
+	ShowScores      bool
+}
+
+func (request *LeaderboardRequest) String() string {
+	return common.FormatStruct(request)
+}
+
+type LeaderboardResponse struct {
+	BeatmapChecksum string
+	Unknown         uint64
+	NeedsUpdate     bool
+	Status          common.BeatmapStatus
+	ShowScores      bool
+}
+
+func (request *LeaderboardResponse) String() string {
+	return common.FormatStruct(request)
+}

--- a/hnet/parsers.go
+++ b/hnet/parsers.go
@@ -180,3 +180,15 @@ func ReadScorePack(stream *common.IOStream) *ScorePack {
 		Frames: frames,
 	}
 }
+
+func ReadLeaderboardRequest(stream *common.IOStream) *LeaderboardRequest {
+	defer recover()
+
+	return &LeaderboardRequest{
+		BeatmapChecksum: stream.ReadString(),
+		Unknown:         stream.ReadU64(),
+		SetId:           stream.ReadU32(),
+		BeatmapId:       stream.ReadU32(),
+		ShowScores:      stream.ReadBool(),
+	}
+}

--- a/hnet/writers.go
+++ b/hnet/writers.go
@@ -125,3 +125,24 @@ func (pack ScorePack) Serialize(stream *common.IOStream) {
 		frame.Serialize(stream)
 	}
 }
+
+func (request LeaderboardRequest) Serialize(stream *common.IOStream) {
+	stream.WriteString(request.BeatmapChecksum)
+	stream.WriteU64(request.Unknown)
+	stream.WriteU32(request.SetId)
+	stream.WriteU32(request.BeatmapId)
+	stream.WriteBool(request.ShowScores)
+}
+
+func (response LeaderboardResponse) Serialize(stream *common.IOStream) {
+	stream.WriteString(response.BeatmapChecksum)
+	stream.WriteU64(response.Unknown)
+	stream.WriteBool(response.NeedsUpdate)
+	stream.WriteU8(uint8(response.Status))
+
+	if !response.ShowScores {
+		return
+	}
+
+	// TODO: write scores
+}


### PR DESCRIPTION
Starts a basic stub for leaderboard response (packet id 25), also adding a reader object for the leaderboard request (also id 25)

See #25 