### PR TITLE
Add forum database schema

### DIFF
--- a/common/database_queries.go
+++ b/common/database_queries.go
@@ -284,6 +284,129 @@ func RemoveBeatmapsBySetId(setId int, state *State) error {
 	return nil
 }
 
+func CreateForum(forum *Forum, state *State) error {
+	result := state.Database.Create(forum)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+func FetchForumById(id int, state *State, preload ...string) (*Forum, error) {
+	forum := &Forum{}
+	result := preloadQuery(state, preload).First(forum, id)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return forum, nil
+}
+
+func UpdateForum(forum *Forum, state *State) error {
+	result := state.Database.Save(forum)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+func DeleteForum(forum *Forum, state *State) error {
+	result := state.Database.Delete(forum)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+func CreateTopic(topic *ForumTopic, state *State) error {
+	result := state.Database.Create(topic)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+func FetchTopicById(id int, state *State, preload ...string) (*ForumTopic, error) {
+	topic := &ForumTopic{}
+	result := preloadQuery(state, preload).First(topic, id)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return topic, nil
+}
+
+func UpdateTopic(topic *ForumTopic, state *State) error {
+	result := state.Database.Save(topic)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+func DeleteTopic(topic *ForumTopic, state *State) error {
+	result := state.Database.Delete(topic)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+func CreatePost(post *ForumPost, state *State) error {
+	result := state.Database.Create(post)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+func FetchPostById(id int, state *State, preload ...string) (*ForumPost, error) {
+	post := &ForumPost{}
+	result := preloadQuery(state, preload).First(post, id)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return post, nil
+}
+
+func UpdatePost(post *ForumPost, state *State) error {
+	result := state.Database.Save(post)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+func DeletePost(post *ForumPost, state *State) error {
+	result := state.Database.Delete(post)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
 func preloadQuery(state *State, preload []string) *gorm.DB {
 	result := state.Database
 

--- a/common/database_queries.go
+++ b/common/database_queries.go
@@ -305,6 +305,17 @@ func FetchForumById(id int, state *State, preload ...string) (*Forum, error) {
 	return forum, nil
 }
 
+func FetchForumByName(name string, state *State, preload ...string) (*Forum, error) {
+	forum := &Forum{}
+	result := preloadQuery(state, preload).First(forum, "name = ?", name)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return forum, nil
+}
+
 func UpdateForum(forum *Forum, state *State) error {
 	result := state.Database.Save(forum)
 

--- a/common/database_schemas.go
+++ b/common/database_schemas.go
@@ -75,9 +75,11 @@ type Beatmapset struct {
 	HasVideo           bool                `gorm:"not null;default:false"`
 	AvailabilityStatus BeatmapAvailability `gorm:"not null;default:0"`
 	AvailabilityInfo   string              `gorm:"type:text;not null;default:''"`
+	TopicId            *int                `gorm:"default:null"`
 
-	Beatmaps []Beatmap `gorm:"foreignKey:SetId"`
-	Creator  User      `gorm:"foreignKey:CreatorId"`
+	Beatmaps []Beatmap  `gorm:"foreignKey:SetId"`
+	Topic    ForumTopic `gorm:"foreignKey:TopicId"`
+	Creator  User       `gorm:"foreignKey:CreatorId"`
 }
 
 type Beatmap struct {

--- a/common/database_schemas.go
+++ b/common/database_schemas.go
@@ -40,15 +40,6 @@ type Stats struct {
 	DCount      int     `gorm:"not null;default:0"`
 }
 
-type Relationship struct {
-	UserId   int                `gorm:"primaryKey;not null"`
-	TargetId int                `gorm:"primaryKey;not null"`
-	Status   RelationshipStatus `gorm:"type:relationship_status;not null"`
-
-	User   User `gorm:"foreignKey:UserId"`
-	Target User `gorm:"foreignKey:TargetId"`
-}
-
 func (user *User) EnsureStats(state *State) error {
 	if user.Stats.UserId != 0 {
 		return nil
@@ -57,6 +48,15 @@ func (user *User) EnsureStats(state *State) error {
 	// Create new stats object
 	user.Stats = Stats{UserId: user.Id}
 	return CreateStats(&user.Stats, state)
+}
+
+type Relationship struct {
+	UserId   int                `gorm:"primaryKey;not null"`
+	TargetId int                `gorm:"primaryKey;not null"`
+	Status   RelationshipStatus `gorm:"type:relationship_status;not null"`
+
+	User   User `gorm:"foreignKey:UserId"`
+	Target User `gorm:"foreignKey:TargetId"`
 }
 
 type Beatmapset struct {

--- a/common/database_schemas.go
+++ b/common/database_schemas.go
@@ -109,3 +109,50 @@ type Beatmap struct {
 	Set     Beatmapset `gorm:"foreignKey:SetId"`
 	Creator User       `gorm:"foreignKey:CreatorId"`
 }
+
+type Forum struct {
+	Id          int       `gorm:"primaryKey;autoIncrement;not null"`
+	ParentId    *int      `gorm:"default:null"`
+	CreatedAt   time.Time `gorm:"not null;default:now()"`
+	Name        string    `gorm:"size:32;not null"`
+	Description string    `gorm:"size:255;not null;default:''"`
+	Hidden      bool      `gorm:"not null;default:false"`
+
+	Parent *Forum `gorm:"foreignKey:ParentId"`
+}
+
+type ForumTopic struct {
+	Id           int       `gorm:"primaryKey;autoIncrement;not null"`
+	ForumId      int       `gorm:"not null"`
+	CreatorId    int       `gorm:"not null"`
+	Title        string    `gorm:"size:255;not null"`
+	StatusText   *string   `gorm:"size:255;default:null"`
+	CreatedAt    time.Time `gorm:"not null;default:now()"`
+	LastPostAt   time.Time `gorm:"not null;default:now()"`
+	LockedAt     *time.Time
+	Views        int  `gorm:"not null;default:0"`
+	Announcement bool `gorm:"not null;default:false"`
+	Hidden       bool `gorm:"not null;default:false"`
+	Pinned       bool `gorm:"not null;default:false"`
+
+	Forum   Forum `gorm:"foreignKey:ForumId"`
+	Creator User  `gorm:"foreignKey:CreatorId"`
+}
+
+type ForumPost struct {
+	Id         int       `gorm:"primaryKey;autoIncrement;not null"`
+	TopicId    int       `gorm:"not null"`
+	ForumId    int       `gorm:"not null"`
+	UserId     int       `gorm:"not null"`
+	Content    string    `gorm:"type:text;not null"`
+	CreatedAt  time.Time `gorm:"not null;default:now()"`
+	EditTime   time.Time `gorm:"not null;default:now()"`
+	EditCount  int       `gorm:"not null;default:0"`
+	EditLocked bool      `gorm:"not null;default:false"`
+	Hidden     bool      `gorm:"not null;default:false"`
+	Deleted    bool      `gorm:"not null;default:false"`
+
+	Topic ForumTopic `gorm:"foreignKey:TopicId"`
+	Forum Forum      `gorm:"foreignKey:ForumId"`
+	User  User       `gorm:"foreignKey:UserId"`
+}


### PR DESCRIPTION
This pr will add the new schemas over from https://github.com/hexis-revival/hexagon-deploy/pull/2 to hexagon. I would like to add a `topic_id` key to the `beatmapsets` table first, before merging.