### PR TITLE
Migrate `score` table to hexagon

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -38,3 +38,12 @@ const (
 	BeatmapHasDMCA                 BeatmapAvailability = iota
 	BeatmapHasInappropriateContent BeatmapAvailability = iota
 )
+
+type ScoreStatus int
+
+const (
+	ScoreStatusFailed    ScoreStatus = iota
+	ScoreStatusSubmitted ScoreStatus = iota
+	ScoreStatusPB        ScoreStatus = iota
+	ScoreStatusModsPB    ScoreStatus = iota
+)

--- a/common/database_queries.go
+++ b/common/database_queries.go
@@ -429,6 +429,47 @@ func DeletePost(post *ForumPost, state *State) error {
 	return nil
 }
 
+func CreateScore(score *Score, state *State) error {
+	result := state.Database.Create(score)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+func FetchScoreById(id int, state *State, preload ...string) (*Score, error) {
+	score := &Score{}
+	result := preloadQuery(state, preload).First(score, id)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return score, nil
+}
+
+func UpdateScore(score *Score, state *State) error {
+	result := state.Database.Save(score)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+func DeleteScore(score *Score, state *State) error {
+	result := state.Database.Delete(score)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
 func preloadQuery(state *State, preload []string) *gorm.DB {
 	result := state.Database
 

--- a/common/database_schemas.go
+++ b/common/database_schemas.go
@@ -158,3 +158,38 @@ type ForumPost struct {
 	Forum Forum      `gorm:"foreignKey:ForumId"`
 	User  User       `gorm:"foreignKey:UserId"`
 }
+
+type Score struct {
+	Id            int         `gorm:"primaryKey;autoIncrement;not null"`
+	BeatmapId     int         `gorm:"not null"`
+	UserId        int         `gorm:"not null"`
+	Checksum      string      `gorm:"size:32;not null"`
+	Status        ScoreStatus `gorm:"not null"`
+	CreatedAt     time.Time   `gorm:"not null;default:now()"`
+	ClientVersion int         `gorm:"not null"`
+	TotalScore    int64       `gorm:"not null"`
+	MaxCombo      int         `gorm:"not null"`
+	Accuracy      float64     `gorm:"not null"`
+	FullCombo     bool        `gorm:"not null"`
+	Passed        bool        `gorm:"not null"`
+	Grade         Grade       `gorm:"type:grade;not null"`
+	Count300      int         `gorm:"not null"`
+	Count100      int         `gorm:"not null"`
+	Count50       int         `gorm:"not null"`
+	CountGeki     int         `gorm:"not null"`
+	CountKatu     int         `gorm:"not null"`
+	CountGood     int         `gorm:"not null"`
+	CountMiss     int         `gorm:"not null"`
+	AROffset      int         `gorm:"not null"`
+	ODOffset      int         `gorm:"not null"`
+	CSOffset      int         `gorm:"not null"`
+	HPOffset      int         `gorm:"not null"`
+	PSOffset      int         `gorm:"not null"`
+	ModHidden     bool        `gorm:"not null"`
+	ModNoFail     bool        `gorm:"not null"`
+	Visible       bool        `gorm:"not null;default:true"`
+	Pinned        bool        `gorm:"not null;default:false"`
+
+	Beatmap Beatmap `gorm:"foreignKey:BeatmapId"`
+	User    User    `gorm:"foreignKey:UserId"`
+}

--- a/hscore/scoring.go
+++ b/hscore/scoring.go
@@ -26,8 +26,8 @@ func ScoreSubmissionHandler(ctx *Context) {
 	ctx.Response.Header().Set("Content-Type", "application/json")
 
 	// Write response
-	resp := ScoreSubmissionResponse{Success: true}
-	json.NewEncoder(ctx.Response).Encode(resp)
+	response := ScoreSubmissionResponse{Success: true}
+	json.NewEncoder(ctx.Response).Encode(response)
 }
 
 func NewScoreSubmissionRequest(request *http.Request) (*ScoreSubmissionRequest, error) {


### PR DESCRIPTION
This pr adds the `score` table from [hexagon-deploy](https://github.com/hexis-revival/hexagon-deploy/commit/35028a2401fd086f9a9ecf7b8e23b39bcbd4c468) over to hexagon.