### PR TITLE
Implement playtime updates

### DIFF
--- a/common/database_queries.go
+++ b/common/database_queries.go
@@ -82,6 +82,19 @@ func UpdateStats(stats *Stats, state *State) error {
 	return nil
 }
 
+func UpdatePlaytime(userId int, secondsToAdd int, state *State) error {
+	result := state.Database.Exec(
+		"UPDATE stats SET playtime = playtime + ? WHERE user_id = ?",
+		secondsToAdd, userId,
+	)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
 func CreateUserRelationship(relationship *Relationship, state *State) error {
 	result := state.Database.Create(relationship)
 

--- a/hnet/handler.go
+++ b/hnet/handler.go
@@ -3,6 +3,7 @@ package hnet
 import (
 	"encoding/hex"
 	"fmt"
+	"math"
 
 	"github.com/hexis-revival/hexagon/common"
 )
@@ -121,11 +122,12 @@ func handleStatusChange(stream *common.IOStream, player *Player) error {
 
 	if player.Stats.Status.Action == ACTION_PLAYING {
 		time := player.Stats.Status.TimeSinceChanged()
+		seconds := math.Min(time.Seconds(), 3600*5)
 
 		// Update user's playtime
 		err := common.UpdatePlaytime(
 			int(player.Info.Id),
-			int(time.Seconds()),
+			int(seconds),
 			player.Server.State,
 		)
 

--- a/hnet/handler.go
+++ b/hnet/handler.go
@@ -119,6 +119,21 @@ func handleStatusChange(stream *common.IOStream, player *Player) error {
 		return fmt.Errorf("failed to read status change")
 	}
 
+	if player.Stats.Status.Action == ACTION_PLAYING {
+		time := player.Stats.Status.TimeSinceChanged()
+
+		// Update user's playtime
+		err := common.UpdatePlaytime(
+			int(player.Info.Id),
+			int(time.Seconds()),
+			player.Server.State,
+		)
+
+		if err != nil {
+			player.Logger.Errorf("Failed to update playtime: %s", err)
+		}
+	}
+
 	player.LogIncomingPacket(CLIENT_CHANGE_STATUS, status)
 	player.Stats.Status = status
 

--- a/hnet/objects.go
+++ b/hnet/objects.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hexis-revival/hexagon/common"
 )
@@ -89,11 +90,12 @@ func (info VersionInfo) String() string {
 }
 
 type Status struct {
-	UserId   uint32
-	Action   uint32
-	Beatmap  *BeatmapInfo
-	Watching string
-	Mods     *Mods
+	UserId      uint32
+	Action      uint32
+	Beatmap     *BeatmapInfo
+	Watching    string
+	Mods        *Mods
+	LastChanged time.Time
 }
 
 func (status Status) HasBeatmapInfo() bool {
@@ -106,9 +108,12 @@ func (status Status) String() string {
 
 func NewStatus() *Status {
 	return &Status{
-		UserId:  0,
-		Action:  1,
-		Beatmap: nil,
+		UserId:      0,
+		Action:      1,
+		Beatmap:     nil,
+		Watching:    "",
+		Mods:        nil,
+		LastChanged: time.Now(),
 	}
 }
 

--- a/hnet/objects.go
+++ b/hnet/objects.go
@@ -102,6 +102,10 @@ func (status Status) HasBeatmapInfo() bool {
 	return status.Action > ACTION_AWAY
 }
 
+func (status Status) TimeSinceChanged() time.Duration {
+	return time.Since(status.LastChanged)
+}
+
 func (status Status) String() string {
 	return common.FormatStruct(status)
 }

--- a/hnet/parsers.go
+++ b/hnet/parsers.go
@@ -2,6 +2,7 @@ package hnet
 
 import (
 	"strings"
+	"time"
 
 	"github.com/hexis-revival/hexagon/common"
 )
@@ -85,9 +86,10 @@ func ReadStatusChange(stream *common.IOStream) *Status {
 	defer recover()
 
 	status := &Status{
-		UserId:  stream.ReadU32(),
-		Action:  stream.ReadU32(),
-		Beatmap: nil,
+		UserId:      stream.ReadU32(),
+		Action:      stream.ReadU32(),
+		LastChanged: time.Now(),
+		Beatmap:     nil,
 	}
 
 	if !status.HasBeatmapInfo() {


### PR DESCRIPTION
As addressed in #38, the playtime cannot be calculated in score submission, so this pr implements it via. hnet. I still have to check if this is exploitable somehow, but it works for the most part.